### PR TITLE
Update home page content with professional bio

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,14 +4,14 @@ export default function Page() {
   return (
     <section>
       <h1 className="mb-8 text-2xl font-semibold tracking-tighter">
-        My Portfolio
+        Raman Shrivastava
       </h1>
       <p className="mb-4">
-        {`I'm a Vim enthusiast and tab advocate, finding unmatched efficiency in
-        Vim's keystroke commands and tabs' flexibility for personal viewing
-        preferences. This extends to my support for static typing, where its
-        early error detection ensures cleaner code, and my preference for dark
-        mode, which eases long coding sessions by reducing eye strain.`}
+        {`14 years of professional experience in Artificial Intelligence both as an Entrepreneurial Leader and hands-on execution training + deploying models.
+
+        As a co-founder & Head of AI at CustomerGlu, I built a low code SaaS platform to run gamification campaigns at scale, using Generative AI to create experiments in minutes. CustomerGlu is a Techstars backed startup that helps businesses increase user engagement and retention through gamification.
+
+        With over 14 years of experience in AI engineering and leadership, I have a proven track record of building innovative and impactful products using cutting-edge technologies such as deep reinforcement learning, LLMs and deep learning. I have also been recognized as one of the 40 under 40 data scientists in India by Analytics India Magazine in 2019. My mission is to leverage AI, cloud and data to solve real-world problems and create positive change.`}
       </p>
       <div className="my-8">
         <BlogPosts />


### PR DESCRIPTION
## Summary
- Updated the home page title from "My Portfolio" to "Raman Shrivastava"
- Replaced the placeholder text with Raman Shrivastava's professional bio highlighting 14 years of AI experience
- Added information about CustomerGlu co-founding experience and recognition as 40 under 40 data scientist

## Test plan
- [ ] Verify the home page displays the updated content correctly
- [ ] Check text formatting and readability
- [ ] Ensure no layout issues with the longer bio text